### PR TITLE
Update Text.simba

### DIFF
--- a/Interfaces.Simba
+++ b/Interfaces.Simba
@@ -39,36 +39,27 @@ type GL_SKILL_LEVEL = (SKILL_ATTACK, SKILL_CONSTITUTION, SKILL_MINING, SKILL_STR
 
   Developer Info:
     3084480 = TextureID of the Action Bar's background.
-    27185   =  TextureID of the Heart icon on the Action Bar.
-    11475   = Minimize button on the action bar.
 *}
 Function TActionBar.GetBounds: TBox;
 var
   T: glTextureArray;
-  Heart, Minimise: glTextureArray;
+  controlPanel: TControlPanel;
   Areas: TBoxArray;
   I: Integer;
 Begin
-  T := glGetTextures(3084480);
-  Heart := glGetTextures(27185);
-  Minimise := glGetTextures(11475, 4603438, 10);
   Result := IntToBox(-1, -1, -1, -1);
 
+  T := glGetTextures(3084480);
   For I := 0 To High(T) Do
   Begin
-    If (T[I].StableBounds().Contains(Heart[0].StableBounds().MidPoint())) Then
-    begin
-      SetLength(Areas, length(Areas) + 1);
-      Areas[0] := T[I].Bounds;
-    end else
-      If (T[I].StableBounds().Contains(Minimise[0].StableBounds().MidPoint())) Then
-      begin
-        SetLength(Areas, length(Areas) + 1);
-        Areas[1] := T[I].Bounds;
-      end;
+    If (controlPanel.GetBounds().Contains(T[I].StableBounds().MidPoint())) Then
+      Continue;
+
+    SetLength(Areas, Length(Areas) + 1);
+    Areas[High(Areas)] := T[I].Bounds;
   End;
 
-  If (Areas[0].X1 > 0) Then
+  If Length(Areas) > 0 Then
     Result := Areas.Bounds;
 End;
 
@@ -300,6 +291,7 @@ End;
   Developer Info:
     3084480    - TextureID of the Control Panel's background.
     163200     - TextureID of the Background of each button.
+    2413       - TextureID of the customisation button.
 *}
 Function TControlPanel.GetBounds: TBox;
 var
@@ -309,7 +301,7 @@ var
 Begin
   Result := IntToBox(-1, -1, -1, -1);
   Background := glGetTextures(3084480);
-  Icons := glGetTextures(163200);
+  Icons := glGetTextures([163200, 2413]);
 
   For I := 0 To High(Background) Do
     For J := 0 To High(Icons) Do
@@ -318,15 +310,12 @@ Begin
       Begin
         SetLength(TBA, Length(TBA) + 1);
         TBA[High(TBA)] := Background[I].Bounds;
+        Break;
       End;
     End;
 
-  If (Length(TBA) > 1) Then
-  Begin
-    Result := TBA.Bounds;
-    Exit;
-  End;
-  Result := IntToBox(-1, -1, -1, -1);
+  If (Length(TBA) > 0) Then
+    Exit(TBA.Bounds);
 End;
 
 {*

--- a/Inventory.simba
+++ b/Inventory.simba
@@ -18,11 +18,11 @@
     386611   - TextureID of the corners of the minimap.
 *}
 Function GL_InvBounds: TBox;
-Label Skip;
 var
   I, J: Integer;
   ChatBox: TBox;
   Background, Others: glTextureArray;
+  Areas: TBoxArray;
 Begin
   If (UseSysCache) Then
   Begin
@@ -47,15 +47,19 @@ Begin
     For J := 0 To High(Others) Do
     Begin
       If (PointInBox(Point(Others[J].X, Others[J].Y), Background[I].Bounds)) or (PointInBox(Background[I].Bounds.MidPoint, ChatBox)) Then
-        Goto Skip;
+        Continue(2);
     End;
 
-    Result := Background[I].Bounds;
-    If (UseSysCache) Then
-        SysCache.CacheInventory(Result);
-    Exit;
-    Skip:
+    SetLength(Areas, Length(Areas) + 1);
+    Areas[High(Areas)] := Background[I].Bounds;
   End;
+
+  if Length(Areas) = 0 then
+    Exit;
+
+  Result := Areas.Bounds;
+  If (UseSysCache) Then
+      SysCache.CacheInventory(Result);
 End;
 
 {*

--- a/Misc/Smart.simba
+++ b/Misc/Smart.simba
@@ -43,7 +43,7 @@ Begin
     Exit;
   end;
 
-  Self.__Target := SmartSpawnClient('C:/Program Files (x86)/Java/jre8/bin/java.exe', Replace(PluginPath, '\', '/', [rfReplaceAll]), Params[0], ',' + Params[1], Width, Height, InitSequence, '', '-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=30', Implode(',', Plugins));
+  Self.__Target := SmartSpawnClient(GetJavaPath(False), Replace(PluginPath, '\', '/', [rfReplaceAll]), Params[0], ',' + Params[1], Width, Height, InitSequence, '', '-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=30', Implode(',', Plugins));
   If (Self.__Target <> 0) Then
   begin
     try

--- a/Text.simba
+++ b/Text.simba
@@ -146,7 +146,7 @@ Begin
       If (Background[I].Bounds.Contains(chatBoxIcons[J].Bounds.MidPoint)) then
       begin
         if (Length(invIcons) > 0) then
-          if (not Background[I].Bounds.Contains(invIcons[0].Bounds.MidPoint)) then
+          if (Background[I].Bounds.Contains(invIcons[0].Bounds.MidPoint)) then
             Continue;
 
         SetLength(Areas, Length(Areas) + 1);

--- a/Text.simba
+++ b/Text.simba
@@ -123,7 +123,7 @@ Function GL_ChatBounds: TBox;
 var
   I, J: Integer;
   Areas: TBoxArray;
-  Messages, Background, Info: glTextureArray;
+  Background, chatBoxIcons, invIcons: glTextureArray;
 Begin
   If (UseSysCache) Then
   Begin
@@ -135,35 +135,30 @@ Begin
     End;
   End;
 
+  Result:= IntToBox(-1, -1, -1, -1);
+
   Background := glGetTextures(3786240);
-  Messages := glGetTextures([9122, 16262], [7491604, 2111553], [10, 10]);
-  Info := glGetTextures([2732, 16262], [2825218, 2111553], [10, 10]);
+  chatBoxIcons := glGetTextures([2732, 9122, 16262]);
+  invIcons := glGetTextures(73440);
+  if (Length(invIcons) < 1) then
+    Exit();
 
   For I := 0 To High(Background) Do
-    For J := 0 To High(Messages) Do
-      If (Background[I].Bounds.Contains(Messages[J].Bounds.MidPoint)) then
-      begin
-        SetLength(Areas, Length(Areas) + 1);
-        Areas[High(Areas)] := Background[I].Bounds;
-      end;
+    For J := 0 To High(chatBoxIcons) Do
+      If (Background[I].Bounds.Contains(chatBoxIcons[J].Bounds.MidPoint)) then
+        if (not Background[I].Bounds.Contains(invIcons[0].Bounds.MidPoint)) then
+        begin
+          SetLength(Areas, Length(Areas) + 1);
+          Areas[High(Areas)] := Background[I].Bounds;
+          Break;
+        end;
 
-  For I := 0 To High(Background) Do
-    For J := 0 To High(Info) Do
-      If (Background[I].Bounds.Contains(Info[J].Bounds.MidPoint)) then
-      begin
-        SetLength(Areas, Length(Areas) + 1);
-        Areas[High(Areas)] := Background[I].Bounds;
-      end;
-
-  If (Length(Areas) > 1) Then
+  If (Length(Areas) > 0) Then
   Begin
     Result := Areas.Bounds;
     If (UseSysCache) Then
       SysCache.CacheChat(Result);
-    Exit;
   End;
-
-  Result := IntToBox(-1, -1, -1, -1);
 End;
 
 {*

--- a/Text.simba
+++ b/Text.simba
@@ -118,6 +118,7 @@ End;
     2732    -   TextureID of the info button (at the top right of the chat box).
     9122    -   TextureID of the game-messages button (at the top left of the char box).
     16262   -   TextureID of the chat-actions button (on the smallest possible chat screen).
+    73440   -   TextureID of the money pouch and buttons beside it (at the bottom of inventory).
 *}
 Function GL_ChatBounds: TBox;
 var

--- a/Text.simba
+++ b/Text.simba
@@ -140,18 +140,19 @@ Begin
   Background := glGetTextures(3786240);
   chatBoxIcons := glGetTextures([2732, 9122, 16262]);
   invIcons := glGetTextures(73440);
-  if (Length(invIcons) < 1) then
-    Exit();
 
   For I := 0 To High(Background) Do
     For J := 0 To High(chatBoxIcons) Do
       If (Background[I].Bounds.Contains(chatBoxIcons[J].Bounds.MidPoint)) then
-        if (not Background[I].Bounds.Contains(invIcons[0].Bounds.MidPoint)) then
-        begin
-          SetLength(Areas, Length(Areas) + 1);
-          Areas[High(Areas)] := Background[I].Bounds;
-          Break;
-        end;
+      begin
+        if (Length(invIcons) > 0) then
+          if (not Background[I].Bounds.Contains(invIcons[0].Bounds.MidPoint)) then
+            Continue;
+
+        SetLength(Areas, Length(Areas) + 1);
+        Areas[High(Areas)] := Background[I].Bounds;
+        Break;
+      end;
 
   If (Length(Areas) > 0) Then
   Begin

--- a/Text.simba
+++ b/Text.simba
@@ -116,8 +116,8 @@ End;
   Developer Info:
     3786240 -   TextureID of the chatbox background (found in the middle of the chatbox).
     2732    -   TextureID of the info button (at the top right of the chat box).
-    9122    -   TextureID of the game-messages button (at the top left of the char box).
-    16262   -   TextureID of the chat-actions button (on the smallest possible chat screen).
+    9176    -   TextureID of the game-messages button (at the top left of the char box).
+    16316   -   TextureID of the chat-actions button (on the smallest possible chat screen).
     73440   -   TextureID of the money pouch and buttons beside it (at the bottom of inventory).
 *}
 Function GL_ChatBounds: TBox;
@@ -139,7 +139,7 @@ Begin
   Result:= IntToBox(-1, -1, -1, -1);
 
   Background := glGetTextures(3786240);
-  chatBoxIcons := glGetTextures([2732, 9122, 16262]);
+  chatBoxIcons := glGetTextures([2732, 9176, 16316]);
   invIcons := glGetTextures(73440);
 
   For I := 0 To High(Background) Do


### PR DESCRIPTION
1. for control panel & action bar changes:
   http://puu.sh/aUUgh/fcfb6c8606.jpg
   1 more small region for control panel not included
   action bar's minimize not at end when sized that way.
2. for chat bounds changes:
   http://puu.sh/aULWq/93a309cce0.jpg
   game message button's color can change if u toggle it.
   chat-actions button is present in inventory bound as well if you re-size it smaller.
   just have to do the loop thing once?

It still wont work if 
http://puu.sh/aUMma/fb452f3ab4.jpg
http://puu.sh/aUMnG/cc7d8460f4.jpg
but i couldn't think of any good way to solve these 2 cases...
